### PR TITLE
[hook] Add custom command to hook

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,13 @@
+{
+  "packages": [
+    "go@latest",
+    "runx:golangci/golangci-lint@latest"
+  ],
+  "shell": {
+    "scripts": {
+      "build": "go build -o dist/direnv main.go",
+      "lint": "golangci-lint run",
+      "test": "go test ./..."
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,29 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "go@latest": {
+      "last_modified": "2023-09-27T18:02:17Z",
+      "resolved": "github:NixOS/nixpkgs/517501bcf14ae6ec47efd6a17dda0ca8e6d866f9#go_1_21",
+      "source": "devbox-search",
+      "version": "1.21.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/s1xk6hrfn0kw8ycvqbx4vv4gr00k6qpl-go-1.21.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/id3ygqxp1hvbh7dyjlwngx53fvcpqg84-go-1.21.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/yn0g820ayb963s0i4nnw9pf72l49kkg0-go-1.21.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/pvvv2lmx9m8b2n0447mljrl5xmla8r3h-go-1.21.1"
+        }
+      }
+    },
+    "runx:golangci/golangci-lint@latest": {
+      "resolved": "golangci/golangci-lint@v1.55.0",
+      "version": "v1.55.0"
+    }
+  }
+}

--- a/internal/cmd/cmd_hook.go
+++ b/internal/cmd/cmd_hook.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -28,6 +29,10 @@ func cmdHookAction(_ Env, args []string) (err error) {
 		target = args[1]
 	}
 
+	fs := flag.NewFlagSet("hook", flag.ContinueOnError)
+	customCmd := fs.String("cmd", "", "Custom command to run as a hook")
+	fs.Parse(args[2:])
+
 	selfPath, err := os.Executable()
 	if err != nil {
 		return err
@@ -42,7 +47,12 @@ func cmdHookAction(_ Env, args []string) (err error) {
 		return fmt.Errorf("unknown target shell '%s'", target)
 	}
 
-	hookStr, err := shell.Hook()
+	hookStr := ""
+	if *customCmd != "" {
+		hookStr, err = shell.CustomHook(*customCmd)
+	} else {
+		hookStr, err = shell.Hook()
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -10,6 +10,9 @@ type Shell interface {
 	// setups direnv as a prompt hook.
 	Hook() (string, error)
 
+	// Custom hook sets up a custom hook for the shell
+	CustomHook(cmd string) (string, error)
+
 	// Export outputs the ShellExport as an evaluatable string on the host shell
 	Export(e ShellExport) string
 

--- a/internal/cmd/shell_bash.go
+++ b/internal/cmd/shell_bash.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type bash struct{}
 
@@ -22,6 +25,10 @@ fi
 
 func (sh bash) Hook() (string, error) {
 	return bashHook, nil
+}
+
+func (sh bash) CustomHook(cmd string) (string, error) {
+	return "", errors.New("this feature is not supported")
 }
 
 func (sh bash) Export(e ShellExport) (out string) {
@@ -58,7 +65,7 @@ func (sh bash) escape(str string) string {
  * Escaping
  */
 
-//nolint
+// nolint
 const (
 	ACK           = 6
 	TAB           = 9

--- a/internal/cmd/shell_elvish.go
+++ b/internal/cmd/shell_elvish.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 )
 
 type elvish struct{}
@@ -30,6 +31,10 @@ set @edit:before-readline = $@edit:before-readline {
 	}
 }
 `, nil
+}
+
+func (sh elvish) CustomHook(cmd string) (string, error) {
+	return "", errors.New("this feature is not supported")
 }
 
 func (sh elvish) Export(e ShellExport) string {

--- a/internal/cmd/shell_fish.go
+++ b/internal/cmd/shell_fish.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -38,6 +39,10 @@ const fishHook = `
 
 func (sh fish) Hook() (string, error) {
 	return fishHook, nil
+}
+
+func (sh fish) CustomHook(cmd string) (string, error) {
+	return "", errors.New("this feature is not supported")
 }
 
 func (sh fish) Export(e ShellExport) (out string) {

--- a/internal/cmd/shell_gha.go
+++ b/internal/cmd/shell_gha.go
@@ -14,6 +14,10 @@ func (sh gha) Hook() (string, error) {
 	return "", fmt.Errorf("Hook not implemented for GitHub Actions shell")
 }
 
+func (sh gha) CustomHook(cmd string) (string, error) {
+	return "", fmt.Errorf("Hook not implemented for GitHub Actions shell")
+}
+
 func (sh gha) Export(e ShellExport) string {
 	var b strings.Builder
 	for key, value := range e {

--- a/internal/cmd/shell_gzenv.go
+++ b/internal/cmd/shell_gzenv.go
@@ -15,6 +15,10 @@ func (s gzenvShell) Hook() (string, error) {
 	return "", errors.New("the gzenv shell doesn't support hooking")
 }
 
+func (sh gzenvShell) CustomHook(cmd string) (string, error) {
+	return "", errors.New("the gzenv shell doesn't support hooking")
+}
+
 func (s gzenvShell) Export(e ShellExport) string {
 	return gzenv.Marshal(e)
 }

--- a/internal/cmd/shell_json.go
+++ b/internal/cmd/shell_json.go
@@ -16,6 +16,10 @@ func (sh jsonShell) Hook() (string, error) {
 	return "", errors.New("this feature is not supported")
 }
 
+func (sh jsonShell) CustomHook(cmd string) (string, error) {
+	return "", errors.New("this feature is not supported")
+}
+
 func (sh jsonShell) Export(e ShellExport) string {
 	out, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {

--- a/internal/cmd/shell_pwsh.go
+++ b/internal/cmd/shell_pwsh.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 )
@@ -33,6 +34,10 @@ else {
 
 `
 	return hook, nil
+}
+
+func (sh pwsh) CustomHook(cmd string) (string, error) {
+	return "", errors.New("this feature is not supported")
 }
 
 func (sh pwsh) Export(e ShellExport) (out string) {

--- a/internal/cmd/shell_tcsh.go
+++ b/internal/cmd/shell_tcsh.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -12,6 +13,10 @@ var Tcsh Shell = tcsh{}
 
 func (sh tcsh) Hook() (string, error) {
 	return "alias precmd 'eval `{{.SelfPath}} export tcsh`'", nil
+}
+
+func (sh tcsh) CustomHook(cmd string) (string, error) {
+	return "", errors.New("this feature is not supported")
 }
 
 func (sh tcsh) Export(e ShellExport) (out string) {

--- a/internal/cmd/shell_vim.go
+++ b/internal/cmd/shell_vim.go
@@ -14,6 +14,10 @@ func (sh vim) Hook() (string, error) {
 	return "", errors.New("this feature is not supported. Install the direnv.vim plugin instead")
 }
 
+func (sh vim) CustomHook(cmd string) (string, error) {
+	return "", errors.New("this feature is not supported. Install the direnv.vim plugin instead")
+}
+
 func (sh vim) Export(e ShellExport) (out string) {
 	for key, value := range e {
 		if value == nil {

--- a/internal/cmd/shell_zsh.go
+++ b/internal/cmd/shell_zsh.go
@@ -1,5 +1,7 @@
 package cmd
 
+import "strings"
+
 // ZSH is a singleton instance of ZSH_T
 type zsh struct{}
 
@@ -24,6 +26,10 @@ fi
 
 func (sh zsh) Hook() (string, error) {
 	return zshHook, nil
+}
+
+func (sh zsh) CustomHook(cmd string) (string, error) {
+	return strings.ReplaceAll(zshHook, `"{{.SelfPath}}" export zsh`, cmd), nil
 }
 
 func (sh zsh) Export(e ShellExport) (out string) {


### PR DESCRIPTION
Not sure how useful this is, I was just messing around with direnv codebase. This could be a part of the solution of removing bin wrappers eventually.

This adds a `--cmd` flag to `hook` command. Allows installing a custom hook:

For example:

`direnv hook zsh --cmd "devbox shellenv"`

As implemented there are a few downsides:

* Single line only, must print command to be "eval'd"
* Replaces existing direnv hook so you only get one.

Alternatives:
* Modify to allow for custom hook name
* Modify to allow multiline.
* Modify to use direnv as library instead (pull out of internal)
